### PR TITLE
adding a global featurizer for the hydrolysed functional group in the reactant

### DIFF
--- a/bondnet/core/molwrapper.py
+++ b/bondnet/core/molwrapper.py
@@ -30,6 +30,7 @@ class MoleculeWrapper:
     def __init__(
         self,
         mol_graph,
+        functional_group=None,
         free_energy=None,
         id=None,
         non_metal_bonds=None,
@@ -42,6 +43,7 @@ class MoleculeWrapper:
         self.pymatgen_mol = mol_graph.molecule
         self.nonmetal_bonds = non_metal_bonds
         self.free_energy = free_energy
+        self.functional_group = functional_group
         self.id = id
         self.atom_features = atom_features
         self.bond_features = bond_features
@@ -528,6 +530,7 @@ def create_wrapper_mol_from_atoms_and_bonds(
     bonds,
     charge=0,
     free_energy=None,
+    functional_group=None,
     identifier=None,
     original_atom_ind=None,
     original_bond_ind=None,
@@ -556,6 +559,7 @@ def create_wrapper_mol_from_atoms_and_bonds(
     mol_wrapper = MoleculeWrapper(
         mol_graph,
         free_energy,
+        functional_group,
         identifier,
         original_atom_ind=original_atom_ind,
         original_bond_mapping=original_bond_ind,

--- a/bondnet/data/dataset.py
+++ b/bondnet/data/dataset.py
@@ -10,7 +10,7 @@ from rdkit import Chem, RDLogger
 from bondnet.dataset.generalized import create_reaction_network_files_and_valid_rows
 from bondnet.data.reaction_network import ReactionInNetwork, ReactionNetwork
 from bondnet.data.transformers import HeteroGraphFeatureStandardScaler, StandardScaler
-from bondnet.data.utils import get_dataset_species
+from bondnet.data.utils import get_dataset_species, get_hydro_data_functional_groups
 from bondnet.utils import to_path, yaml_load, list_split_by_size
 from bondnet.data.utils import create_rxn_graph
 
@@ -1092,7 +1092,6 @@ class ReactionNetworkDatasetPrecomputed(BaseDataset):
             extra_keys=extra_keys,
             extra_info=extra_info,
         )
-
         self.molecules = all_mols
         self.raw_labels = all_labels
         self.extra_features = features
@@ -1145,6 +1144,7 @@ class ReactionNetworkDatasetPrecomputed(BaseDataset):
         self._species = sorted(system_species)
         # this is hard coded and potentially needs to be adjusted for other datasets, this is to have fixed size and order of the species
         self._species = ["C", "F", "H", "N", "O", "Mg", "Li", "S", "Cl", "P", "O", "Br"]
+        
 
         # create dgl graphs
         print("constructing graphs & features....")

--- a/bondnet/data/featurizer.py
+++ b/bondnet/data/featurizer.py
@@ -416,10 +416,11 @@ class GlobalFeaturizerGraph(BaseFeaturizer):
         calculations for the molecule take place
     """
 
-    def __init__(self, allowed_charges=None, solvent_environment=None, dtype="float32"):
+    def __init__(self, allowed_charges=None, solvent_environment=None, fg_info=None, dtype="float32"):
         super(GlobalFeaturizerGraph, self).__init__(dtype)
         self.allowed_charges = allowed_charges
         self.solvent_environment = solvent_environment
+        self.fg_info = fg_info
 
     def __call__(self, mol, **kwargs):
         """
@@ -441,7 +442,7 @@ class GlobalFeaturizerGraph(BaseFeaturizer):
             mw,
         ]
 
-        if self.allowed_charges is not None or self.solvent_environment is not None:
+        if self.allowed_charges is not None or self.solvent_environment is not None or self.fg_info is not None:
             try:
                 feats_info = kwargs["extra_feats_info"]
             except KeyError as e:
@@ -464,6 +465,8 @@ class GlobalFeaturizerGraph(BaseFeaturizer):
                     g += one_hot_encoding(
                         feats_info["environment"], self.solvent_environment
                     )
+            if self.fg_info is not None:
+                g += one_hot_encoding(mol.functional_group, self.fg_info)
 
         feats = torch.tensor([g], dtype=getattr(torch, self.dtype))
 
@@ -471,6 +474,8 @@ class GlobalFeaturizerGraph(BaseFeaturizer):
         self._feature_name = ["num atoms", "num bonds", "molecule weight"]
         if self.allowed_charges is not None:
             self._feature_name += ["charge one hot"] * len(self.allowed_charges)
+        if self.fg_info is not None:
+            self._feature_name += ["hydrolysed functional group"] * len(self.fg_info)
         if self.solvent_environment is not None:
             if len(self.solvent_environment) == 2:
                 self._feature_name += ["solvent"]

--- a/bondnet/data/utils.py
+++ b/bondnet/data/utils.py
@@ -51,6 +51,19 @@ def get_dataset_species_from_json(json_file):
 
     return sorted(system_species)
 
+def get_hydro_data_functional_groups(json_file):
+    """
+    Get all the unique functional groups of the hydrolysis reactions compiled in the dataset
+
+    Args:
+        json_file: hydrolysis dataset containing the reactions
+
+    Returns:
+        list: a sequence of all the unique reacted functional groups in the dataset
+    """
+    df = pd.read_json(json_file)
+    return sorted(list(df['functional_group_reacted'].unique()))
+
 
 def one_hot_encoding(x, allowable_set):
     """One-hot encoding.

--- a/bondnet/dataset/generalized.py
+++ b/bondnet/dataset/generalized.py
@@ -121,6 +121,7 @@ def split_and_map(
     id,
     bonds_nonmetal=None,
     charge=0,
+    functional_group=None,
     extra_feats_atom={},
     extra_feats_bond={},
 ):
@@ -137,6 +138,7 @@ def split_and_map(
         id(str): unique id
         bonds_nonmetal(list of tuples/lists): list nonmetal bonds
         charge(int): charge for molecule
+        functional_group(str): hydrolysed functional group in reactant, None entries in product
         extra_feats(dict): dictionary w/ extra features
 
     returns:
@@ -205,11 +207,13 @@ def split_and_map(
                 )
             else:
                 bond_feats = {}
+            
 
             species_molwrapper = create_wrapper_mol_from_atoms_and_bonds(
                 species_sg,
                 coords_sg,
                 bond_reindex_list,
+                functional_group,
                 atom_features=atom_feats,
                 bond_features=bond_feats,
                 identifier=id + "_" + str(ind_sg),
@@ -277,6 +281,7 @@ def split_and_map(
             elements,
             coords,
             bonds,
+            functional_group,
             atom_features=atom_feats,
             bond_features=bond_feats,
             identifier=id,
@@ -365,6 +370,9 @@ def process_species_graph(
 
     bonds_reactant = row[reactant_key + "_bonds"]
     bonds_products = row[product_key + "_bonds"]
+
+    reactant_functional_group = row["functional_group_reacted"]
+    product_functional_group = None
     try:
         pymat_graph_reactants = row["combined_" + reactant_key + "s_graph"]["molecule"][
             "sites"
@@ -489,6 +497,7 @@ def process_species_graph(
         id=str(row[product_key + "_id"]),
         bonds_nonmetal=bonds_nonmetal_product,
         charge=charge,
+        functional_group=product_functional_group,
         extra_feats_atom=extra_atom_feats_dict_prod,
         extra_feats_bond=extra_bond_feats_dict_prod,
     )
@@ -502,6 +511,7 @@ def process_species_graph(
         id=str(row[reactant_key + "_id"]),
         bonds_nonmetal=bonds_nonmetal_reactant,
         charge=charge,
+        functional_group=reactant_functional_group,
         extra_feats_atom=extra_atom_feats_dict_react,
         extra_feats_bond=extra_bond_feats_dict_react,
     )

--- a/bondnet/model/training_utils.py
+++ b/bondnet/model/training_utils.py
@@ -265,6 +265,9 @@ def get_grapher(features):
         #"partial_spins2" # these might need to be imputed
     """
     """
+    keys_selected_global = ["functional_group_reacted", "charge"]??
+    """
+    """
 
         print("using general atom featurizer w/ electronic info ")
 
@@ -297,7 +300,7 @@ def get_grapher(features):
 
     # find keys with bonds in the name
 
-    keys_selected_atoms, keys_selected_bonds = [], []
+    keys_selected_atoms, keys_selected_bonds, keys_selected_global = [], [], []
 
     for key in features:
         if "bond" in key:
@@ -307,7 +310,17 @@ def get_grapher(features):
                 keys_selected_bonds.append(key[5:])
         else:
             if "indices" not in key:
-                keys_selected_atoms.append(key)
+                if key == "functional_group_reacted":
+                    keys_selected_global.append(key)
+                # elif key == "charge":
+                #     """
+                #     This is global charge of the reactant I presume?
+                #     I need some clarity on this since there is a separate charge we are getting
+                #     from the pymatgen molecules of reactants and products
+                #     """
+                #     keys_selected_global.append(key)              
+                else:
+                    keys_selected_atoms.append(key)
 
     # print("keys_selected_atoms", keys_selected_atoms)
     # print("keys_selected_bonds", keys_selected_bonds)
@@ -317,7 +330,13 @@ def get_grapher(features):
         selected_keys=keys_selected_bonds
     )
 
-    global_featurizer = GlobalFeaturizerGraph(allowed_charges=[-2, -1, 0, 1])
+    if len(keys_selected_global > 0):
+        if('functional_group_reacted' in keys_selected_global):
+            #hard coded for now. Ideally need to implement get_hydro_data_functional_groups
+            fg_list = ['PDK','amide','carbamate','carboxylic acid ester','cyclic carbonate','epoxide','imide','lactam','lactone','nitrile','urea']
+            global_featurizer = GlobalFeaturizerGraph(allowed_charges=[-2, -1, 0, 1], fg_info=fg_list)
+    else:
+        global_featurizer = GlobalFeaturizerGraph(allowed_charges=[-2, -1, 0, 1])
 
     grapher = HeteroCompleteGraphFromMolWrapper(
         atom_featurizer, bond_featurizer, global_featurizer


### PR DESCRIPTION
I basically modified the MoleculeWrapper class to carry the functional group info if the molecule is a reactant. In case of products I assumed the functional group to be `None`. That way the difference feature vector takes care of itself.

Currently I have hard coded the possible list of functional groups. But we can modify that later.